### PR TITLE
fix: Replace go.rice with standard embeds

### DIFF
--- a/cmd/aidoku/cmd/verify.go
+++ b/cmd/aidoku/cmd/verify.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"archive/zip"
+	_ "embed"
 	"errors"
 	"fmt"
 	"image"
@@ -10,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/Aidoku/aidoku-cli/internal/common"
-	rice "github.com/GeertJohan/go.rice"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/xeipuuv/gojsonschema"
@@ -59,6 +59,15 @@ func opaque(im image.Image) bool {
 	return true
 }
 
+//go:embed resources/schemas/filters.schema.json
+var filters string
+
+//go:embed resources/schemas/source.schema.json
+var source string
+
+//go:embed resources/schemas/settings.schema.json
+var settings string
+
 var verifyCmd = &cobra.Command{
 	Use:           "verify <FILES>",
 	Short:         "Test Aidyesu packages if they're ready for publishing",
@@ -73,10 +82,9 @@ var verifyCmd = &cobra.Command{
 
 		zipFiles := common.ProcessGlobs(args)
 
-		box := rice.MustFindBox("resources")
-		filterSchema := gojsonschema.NewStringLoader(box.MustString("schemas/filters.schema.json"))
-		sourceSchema := gojsonschema.NewStringLoader(box.MustString("schemas/source.schema.json"))
-		settingsSchema := gojsonschema.NewStringLoader(box.MustString("schemas/settings.schema.json"))
+		filterSchema := gojsonschema.NewStringLoader(filters)
+		sourceSchema := gojsonschema.NewStringLoader(source)
+		settingsSchema := gojsonschema.NewStringLoader(settings)
 
 		errored := false
 

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,9 @@
 module github.com/Aidoku/aidoku-cli
 
-go 1.18
+go 1.23
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.4
-	github.com/GeertJohan/go.rice v1.0.2
 	github.com/bmatcuk/doublestar/v4 v4.0.2
 	github.com/fatih/color v1.13.0
 	github.com/felixge/httpsnoop v1.0.3
@@ -18,7 +17,6 @@ require (
 )
 
 require (
-	github.com/daaku/go.zipexe v1.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,19 +1,12 @@
 github.com/AlecAivazis/survey/v2 v2.3.4 h1:pchTU9rsLUSvWEl2Aq9Pv3k0IE2fkqtGxazskAMd9Ng=
 github.com/AlecAivazis/survey/v2 v2.3.4/go.mod h1:hrV6Y/kQCLhIZXGcriDCUBtB3wnN7156gMXJ3+b23xM=
-github.com/GeertJohan/go.incremental v1.0.0/go.mod h1:6fAjUhbVuX1KcMD3c8TEgVUqmo4seqhv0i0kdATSkM0=
-github.com/GeertJohan/go.rice v1.0.2 h1:PtRw+Tg3oa3HYwiDBZyvOJ8LdIyf6lAovJJtr7YOAYk=
-github.com/GeertJohan/go.rice v1.0.2/go.mod h1:af5vUNlDNkCjOZeSGFgIJxDje9qdjsO6hshx0gTmZt4=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
-github.com/akavel/rsrc v0.8.0/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
 github.com/bmatcuk/doublestar/v4 v4.0.2 h1:X0krlUVAVmtr2cRoTqR8aDMrDqnB36ht8wpWTiQ3jsA=
 github.com/bmatcuk/doublestar/v4 v4.0.2/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.17 h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
-github.com/daaku/go.zipexe v1.0.0/go.mod h1:z8IiR6TsVLEYKwXAoE/I+8ys/sDkgTzSL0CLnGVd57E=
-github.com/daaku/go.zipexe v1.0.1 h1:wV4zMsDOI2SZ2m7Tdz1Ps96Zrx+TzaK15VbUaGozw0M=
-github.com/daaku/go.zipexe v1.0.1/go.mod h1:5xWogtqlYnfBXkSB1o9xysukNP9GTvaNkqzUZbt3Bw8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -27,7 +20,6 @@ github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHL
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
@@ -41,7 +33,6 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQE9x6ikvDFZS2mDVS3drnohI=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
-github.com/nkovacs/streamquote v1.0.0/go.mod h1:BN+NaZ2CmdKqUuTUXUEm9j95B2TRbpOWpxbJYzzgUsc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -56,10 +47,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fastjson v1.6.3 h1:tAKFnnwmeMGPbwJ7IwxcTPCNr3uIzoIj3/Fh90ra4xc=
 github.com/valyala/fastjson v1.6.3/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
-github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -2,6 +2,7 @@ package build
 
 import (
 	"archive/zip"
+	_ "embed"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,7 +14,6 @@ import (
 	"sync"
 
 	"github.com/Aidoku/aidoku-cli/internal/common"
-	rice "github.com/GeertJohan/go.rice"
 	"github.com/fatih/color"
 	"github.com/segmentio/fasthash/fnv1a"
 	"github.com/valyala/fastjson"
@@ -66,12 +66,12 @@ func BuildWrapper(zipPatterns []string, output string, web bool, webArgs WebTemp
 	return nil
 }
 
+//go:embed web/index.html.tmpl
+var index string
+
 func BuildWeb(args WebTemplateArguments, output string) error {
-	box := rice.MustFindBox("web")
 
-	bytes := box.MustBytes("index.html.tmpl")
-
-	tmpl, err := template.New("index").Parse(string(bytes))
+	tmpl, err := template.New("index").Parse(index)
 	if err != nil {
 		return err
 	}

--- a/internal/templates/rust-template.go
+++ b/internal/templates/rust-template.go
@@ -19,13 +19,13 @@ func RustTemplateGenerator(output string, source Source) error {
 	os.RemoveAll(output + "/res")
 
 	files := map[string]func() []byte{
-		"/Cargo.toml":               templateFactory(box, "rust-template/Cargo.toml.tmpl"),
-		"/build.sh":                 templateFactory(box, "rust-template/build.sh.tmpl"),
-		"/build.ps1":                templateFactory(box, "rust-template/build.ps1.tmpl"),
-		"/.cargo/config":            templateFactory(box, "rust/.cargo/config.tmpl"),
-		"/template/Cargo.toml":      templateFactory(box, "rust-template/template/Cargo.toml.tmpl"),
-		"/template/src/lib.rs":      templateFactory(box, "rust-template/template/src/lib.rs.tmpl"),
-		"/template/src/template.rs": templateFactory(box, "rust-template/template/src/template.rs.tmpl"),
+		"/Cargo.toml":               templateFactory(resources, "rust-template/Cargo.toml.tmpl"),
+		"/build.sh":                 templateFactory(resources, "rust-template/build.sh.tmpl"),
+		"/build.ps1":                templateFactory(resources, "rust-template/build.ps1.tmpl"),
+		"/.cargo/config":            templateFactory(resources, "rust/.cargo/config.tmpl"),
+		"/template/Cargo.toml":      templateFactory(resources, "rust-template/template/Cargo.toml.tmpl"),
+		"/template/src/lib.rs":      templateFactory(resources, "rust-template/template/src/lib.rs.tmpl"),
+		"/template/src/template.rs": templateFactory(resources, "rust-template/template/src/template.rs.tmpl"),
 	}
 	// Make the build script executable
 	err = GenerateFilesFromMap(output, source, files)

--- a/internal/templates/rust.go
+++ b/internal/templates/rust.go
@@ -14,14 +14,14 @@ func RustGenerator(output string, source Source) error {
 	}
 
 	files := map[string]func() []byte{
-		"/src/lib.rs": templateFactory(box, "rust/src/lib.rs.tmpl"),
-		"/Cargo.toml": templateFactory(box, "rust/Cargo.toml.tmpl"),
+		"/src/lib.rs": templateFactory(resources, "rust/src/lib.rs.tmpl"),
+		"/Cargo.toml": templateFactory(resources, "rust/Cargo.toml.tmpl"),
 	}
 	if len(source.TemplateName) == 0 {
 		os.MkdirAll(output+"/.cargo", os.FileMode(0754))
-		files["/.cargo/config"] = templateFactory(box, "rust/.cargo/config.tmpl")
-		files["/build.sh"] = templateFactory(box, "rust/build.sh.tmpl")
-		files["/build.ps1"] = templateFactory(box, "rust/build.ps1.tmpl")
+		files["/.cargo/config"] = templateFactory(resources, "rust/.cargo/config.tmpl")
+		files["/build.sh"] = templateFactory(resources, "rust/build.sh.tmpl")
+		files["/build.ps1"] = templateFactory(resources, "rust/build.ps1.tmpl")
 	}
 	// Make the build script executable
 	err = GenerateFilesFromMap(output, source, files)

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"embed"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,7 +10,6 @@ import (
 	"unicode"
 
 	"github.com/Aidoku/aidoku-cli/internal/common"
-	rice "github.com/GeertJohan/go.rice"
 	"github.com/fatih/color"
 	"github.com/iancoleman/strcase"
 	"golang.org/x/text/runes"
@@ -23,12 +23,17 @@ type Source struct {
 }
 
 var (
-	box = rice.MustFindBox("resources")
+	//go:embed all:resources/*
+	resources embed.FS
 )
 
-func templateFactory(box *rice.Box, path string) func() []byte {
+func templateFactory(box embed.FS, path string) func() []byte {
 	return func() []byte {
-		return box.MustBytes(path)
+		if bytes, err := box.ReadFile("resources/" + path); err != nil {
+			panic(err)
+		} else {
+			return bytes
+		}
 	}
 }
 
@@ -116,9 +121,9 @@ func GenerateCommon(output string, source Source) error {
 	}
 
 	files := map[string]func() []byte{
-		"/res/source.json":   templateFactory(box, "common/res/source.json.tmpl"),
-		"/res/filters.json":  templateFactory(box, "common/res/filters.json.tmpl"),
-		"/res/settings.json": templateFactory(box, "common/res/settings.json.tmpl"),
+		"/res/source.json":   templateFactory(resources, "common/res/source.json.tmpl"),
+		"/res/filters.json":  templateFactory(resources, "common/res/filters.json.tmpl"),
+		"/res/settings.json": templateFactory(resources, "common/res/settings.json.tmpl"),
 	}
 	return GenerateFilesFromMap(output, source, files)
 }


### PR DESCRIPTION
I was getting segfaults trying to run this, stemming from go.rice (same issue as https://github.com/GeertJohan/go.rice/issues/178). Turns out go has it's own built-in embedding now so I just swapped to that.